### PR TITLE
Add Comments

### DIFF
--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -12,12 +12,6 @@ import           Control.Applicative           ((<$>))
 import           Text.ParserCombinators.Parsec
 
 
-parseComment :: Parser ()
-parseComment = do
-    char ';'
-    innards <- many (noneOf ['\n'])
-    return ()
-    
 
 -- backslash double quote escapes a quote inside strings
 quotedChar = noneOf ['\"'] <|> try (string "\\\"" >> return '"')
@@ -71,15 +65,25 @@ parseId = do
                "#f" -> BoolLiteral False
                _    -> Id atom
 
+-- atmosphere
+parseComment :: Parser ()
+parseComment = do
+    char ';'
+    skipMany (noneOf ['\n'])
+    -- skipMany $ char '\n'
+    return ()
+    
+
 whiteSpace :: Parser ()
-whiteSpace = 
-    skipMany1 ( oneOf [' ', '\n'])
-    <|> parseComment
+whiteSpace = do
+    optionMaybe parseComment
+    skipMany1 ( oneOf [' ', '\n']) <?> "whitespace or newline"
+    return ()
 
 optionalWhiteSpace :: Parser ()
-optionalWhiteSpace = 
-    skipMany ( oneOf [' ', '\n'])
-    <|> parseComment
+optionalWhiteSpace = do
+    optionMaybe $ whiteSpace
+    return ()
 
 type Alias = String
 parseModifier :: String -> Alias -> Parser Expr

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -10,6 +10,7 @@ module Parser ( parseLispValue
 import           Base                          (Expr (..), Function)
 import           Control.Applicative           ((<$>))
 import           Text.ParserCombinators.Parsec
+import Text.Parsec.Char
 
 
 
@@ -69,16 +70,22 @@ parseId = do
 parseComment :: Parser ()
 parseComment = do
     char ';'
-    skipMany (noneOf ['\n'])
-    -- skipMany $ char '\n'
+    -- get internals of comment by getting it from here
+    manyTill anyChar (try (eol<|> eof))
     return ()
+        where eol = endOfLine >>return ()
     
 
-whiteSpace :: Parser ()
-whiteSpace = do
-    optionMaybe parseComment
-    skipMany1 ( oneOf [' ', '\n']) <?> "whitespace or newline"
-    return ()
+-- whiteSpace :: Parser ()
+-- whiteSpace = do
+--     optionMaybe parseComment
+--     skipMany1 ( oneOf [' ', '\n']) <?> "whitespace or endOfLine"
+--     return ()
+whiteSpace::Parser()
+whiteSpace = skipMany( parseComment <|> nl <|> spc ) 
+    where nl = endOfLine >>return ()
+          spc = space >> return ()
+
 
 optionalWhiteSpace :: Parser ()
 optionalWhiteSpace = do

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -97,12 +97,6 @@ parseQuasiquote      = parseModifier "`" "quasiquote"
 parseUnquote         = parseModifier "," "unquote"
 parseUnquoteSplicing = parseModifier ",@" "unquote-splicing"
 
--- parseLispValue = do
---     pepe <- parseLispValueNoComments 
---     try parseComment
---     return pepe
-
-
 parseLispValue :: Parser Expr
 parseLispValue = 
         parseString


### PR DESCRIPTION
# Comments

Comments are treated as whitespace and everything till **newline** (or eof) is skipped.

Closes #1 

## Syntax

```lisp
(+ 1 2) ; this is a comment, will span till end of the line
(+ 3 4 ;comments are very useful and 
5) ; doesnt need to be at the end of the entire expression
```

## Examples

### Correctly used
```haskell
parse parseLispValue "(lisk-repl)" "(+ 1 2 ;this is a comment\n)"
```
> `Right (+ 1 2)`

```haskell
parse parseLispValue "(lisk-repl)" "(+ 1 2 );another comment"
```
> `Right (+ 1 2)`

```haskell
parse parseLispValue "(lisk-repl)" "(+ 1 2 );another comment\n"
```
> `Right (+ 1 2)`

### Parse Errors
```haskell
parse parseLispValue "(lisk-repl)" "(+ 1 2 ;comment another\n"
```
> `Left "(lisk-repl)" (line 2, column 1):`
> `unexpected end of input`
> `expecting ")"`

```haskell
parse parseLispValue "(lisk-repl)" "(+ 1 2 ;another comment"
```
> `Left "(lisk-repl)" (line 1, column 24):`
> `unexpected end of input`
> `expecting whitespace or newline`
